### PR TITLE
fix(javascript): Fix requirement for jQuery to be in header

### DIFF
--- a/Resources/views/Datatable/datatable_js.html.twig
+++ b/Resources/views/Datatable/datatable_js.html.twig
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    $(document).ready(function () {
+    document.onreadystatechange = function () {
 
         if (typeof window.pipelineFunctionAlreadyLoaded == 'undefined') {
             {% if view_ajax.pipeline > 0 %}
@@ -145,7 +145,7 @@
             {% endif %}
 
         }, features.delay);
-    });
+    };
 
 </script>
 


### PR DESCRIPTION
* Fix issue which has been caused by jQuery loaded by end of the page. This means if you have jQuery <script> tag just before the end of tag. The datatable would not render and you will get an undefined function error in javascript console and you would need to insert jQuery <script> in the tag.